### PR TITLE
Fix my own bug introduced by changing names.txt

### DIFF
--- a/sourcefiles/randomizer.py
+++ b/sourcefiles/randomizer.py
@@ -26,7 +26,7 @@ import roboribbon
 
 def read_names():
         p = open("names.txt","r")
-        names = p.readline()
+        names = p.readline().strip()
         names = names.split(",")
         p.close()
         return names


### PR DESCRIPTION
A newline was added at the end; this changes the code to strip that whitespace, since many text editors will add a newline when editing.

Sorry about this, I hadn't noticed the newline got added in the last PR. I suspect this wouldn't hurt the actual seed generation, but it might make some weird filenames, so probably best fixed.